### PR TITLE
Remove the hook for post deletion on project delete

### DIFF
--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -7,9 +7,6 @@
 
 use function Translationmanager\Functions\get_supported_post_types;
 
-// CPT Project.
-add_action( 'delete_term_taxonomy', 'Translationmanager\\Functions\\delete_all_projects_posts_based_on_project_taxonomy_term' );
-
 // Projects Taxonomy.
 add_action( 'translationmanager_project_pre_add_form', 'Translationmanager\\Functions\\project_hide_slug' );
 add_action( 'translationmanager_project_pre_edit_form', 'Translationmanager\\Functions\\project_hide_slug' );


### PR DESCRIPTION
See [TM-245](https://inpsyde.atlassian.net/browse/TM-245)

It was reported that when you delete the project then the posts included to that project are also deleted from the other projects. 
During investigation of the problem I have found that the action hook is used to also delete all posts which belong to deleted project from other project, so I have removed that filter.