### PR TITLE
Fix metakey name for Yoast's Focus keyphrase field

### DIFF
--- a/src/Module/YoastSeo/WordPressSeo.php
+++ b/src/Module/YoastSeo/WordPressSeo.php
@@ -31,7 +31,7 @@ class WordPressSeo
         $to_translate = [
             'title',
             'metadesc',
-            'metakeywords',
+            'focuskw',
             'bctitle',
         ];
 


### PR DESCRIPTION
See [TM-244](https://inpsyde.atlassian.net/browse/TM-244)

There was a problem that we were using the wrong value name to get meta key for [Yoast's](https://yoast.com/wordpress/plugins/seo/) **Focus keyphrase** field.
The PR will fix it as the old value name to get this field was changed by Yoast from `metakeywords` to `focuskw`. 