### PR TITLE
Release version 1.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,12 @@
         "sort-packages": true,
         "preferred-install": {
             "inpsyde/multilingualpress": "dist"
+        },
+        "allow-plugins": {
+            "composer/installers": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "oomphinc/composer-installers-extender": true,
+            "barryvdh/composer-cleanup-plugin": true
         }
     },
     "authors": [
@@ -31,7 +37,7 @@
     },
     "require-dev": {
         "php-stubs/wordpress-stubs": "^5.0@stable",
-        "barryvdh/composer-cleanup-plugin": "^0.2.0",
+        "barryvdh/composer-cleanup-plugin": "^0.2.0 || ^0.3.0",
         "brain/monkey": "~2.3",
         "inpsyde/php-coding-standards": "^1.0",
         "phpunit/phpunit": "^8.0 | ^9.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: Inpsyde, Eurotext, paddyullrich, wido
 Tags: translation, api, I18N
 Donate link: https://eurotext-ecommerce.com
 Requires at least: 5.0
-Tested up to: 5.8
-Stable tag: 1.4.1
+Tested up to: 6.1
+Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,14 @@ Just send an email to info@eurotext.de with a request.
 3. project view
 
 == Changelog ==
+= 1.5.0 =
+* Added: Support for PHP 8
+* Fixed: Notices for PHP 8.1
+* Fixed: The name of XliffElementHelper is not used correctly.
+* Fixed: Xliff import missing post type, status and relationship.
+* Fixed: While importing project just single relationship is created.
+* Fixed: Fatal error while bulk translations on PHP 8.0
+
 = 1.4.1 =
 * Fix the name of XliffElementHelper is not used correctly
 * Fix Xliff import missing post type, status and relationship

--- a/translationmanager.php
+++ b/translationmanager.php
@@ -3,7 +3,7 @@
  * Plugin Name: translationMANAGER
  * Plugin URI:  https://eurotext.de/en
  * Description: Translate your content from a WordPress Multisite and MultilingualPress.
- * Version:     1.4.1
+ * Version:     1.5.0
  * Author:      Inpsyde
  * Author URI:  https://inpsyde.com/
  * Text Domain: translationmanager


### PR DESCRIPTION
Changelog:

- Added: Support for PHP 8
- Fixed: Notices for PHP 8.1
- Fixed: The name of XliffElementHelper is not used correctly.
- Fixed: Xliff import missing post type, status and relationship.
- Fixed: While importing project just single relationship is created.
- Fixed: Fatal error while bulk translations on PHP 8.0